### PR TITLE
Configure IDEA Git commit dialog

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="BodyLimit" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="SubjectBodySeparation" enabled="true" level="ERROR" enabled_by_default="true" />
+      <inspection_tool class="SubjectLimit" enabled="true" level="WARNING" enabled_by_default="true">
+        <option name="RIGHT_MARGIN" value="50" />
+      </inspection_tool>
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
     <mapping directory="$PROJECT_DIR$/assets" vcs="Git" />


### PR DESCRIPTION
This change configures' IDEA's Git commit dialog to enforce various
Git commit message style rules.

In particular, this change was made in light of the commit at
bisq-network/bisq-common@920f691cabf461bd129e966b3a899aff8fb39423 (part
of PR bisq-network/bisq-common#22), whose body comment lines run well
past the 72-character right margin and in turn make the output of
`git log` log difficult to read.

This line wrapping is hard to get right without some kind of editor
support, and that's why, among other settings, this change configures
IDEA to automatically wrap commit comment body text at 72 characters.

See bisq-network/style#9